### PR TITLE
Fix casting bug with FUniqueNetId

### DIFF
--- a/Source/OnlineSubsystemEpic/Private/OnlineSessionInterfaceEpic.cpp
+++ b/Source/OnlineSubsystemEpic/Private/OnlineSessionInterfaceEpic.cpp
@@ -1906,7 +1906,7 @@ bool FOnlineSessionEpic::FindSessions(const FUniqueNetId& SearchingPlayerId, con
 	uint32 result = ONLINE_FAIL;
 	SearchSettings->SearchState = EOnlineAsyncTaskState::NotStarted;
 
-	FUniqueNetIdEpic const epicNetId = (FUniqueNetIdEpic)SearchingPlayerId;
+	FUniqueNetIdEpic const epicNetId = static_cast<FUniqueNetIdEpic>(SearchingPlayerId);
 	if (epicNetId.IsEpicAccountIdValid())
 	{
 		if (SearchSettings->bIsLanQuery)


### PR DESCRIPTION
Previously when casting an FUniqueNetId to an FUniqueNetIdEpic
the explicit casting operator would only consider the PUID of
the FUniqueNetId, discarding any EAID.
To fix this, the GetBytes() and GetSize() methods had to be changed.
GetSize() now always returns the maximum size of a PUID and,
if the field is valid, the maximum size of an EAID.
GetBytes() returns a byte representation of the PUID and, if the field
is valid the byte representation of the EAID.
Note that both of them are stored in the same array. The PUID is stored
at index 0, the EAID, stored at EOS_PRODUCTUSERID_MAX_LENGTH.

<!--
IMPORTANT

!!DO NOT INCLUDE ANY CONFIG FILES!!
Any PR with config files will be rejected!

Doing any of the following might get the issue closed without further explanation or engagement.
1. Deleting this template in its entirety
4. Writing an incomplete title, or one without a meaningful abstraction (e.g. "Fixes various bugs")
5. Not writing anything in the issue body

!!IMPORTANT: Please do not create a PR without creating an issue first.!!
-->

# Pull Request Template

## Checklist:

- [ ] The code follows the style guidelines of this project and the [Epic Coding Standard](https://docs.unrealengine.com/en-US/Programming/Development/CodingStandard/index.html)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings


## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. *Any change needs to be discussed before proceeding.*

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


